### PR TITLE
fix: make the cursemaven at last for user defined repo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.moddingx
-version=1.0.3
+version=1.0.4

--- a/plugin/src/main/java/org/moddingx/packdev/platform/curse/CursePlatform.java
+++ b/plugin/src/main/java/org/moddingx/packdev/platform/curse/CursePlatform.java
@@ -25,10 +25,11 @@ public class CursePlatform implements ModdingPlatform<CurseFile> {
 
     @Override
     public void initialise(Project project) {
-        project.getRepositories().maven(r -> {
-            r.setUrl(CurseUtil.CURSE_MAVEN);
-            r.content(c -> c.includeGroup("curse.maven"));
-        });
+        project.afterEvaluate((ignored) ->
+                project.getRepositories().maven(r -> {
+                    r.setUrl(CurseUtil.CURSE_MAVEN);
+                    r.content(c -> c.includeGroup("curse.maven"));
+                }));
     }
 
     @Override


### PR DESCRIPTION
The cursemaven PackDev added is the first. I looked into the FG and PackDev. The CurseMaven should be added in `afterEvaluate`.
I edited the packdev and publish to local for testing. It works. And opened a PR
https://github.com/MinecraftForge/ForgeGradle/blob/FG_6.0/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java#L249
https://github.com/ModdingX/PackDev/blob/master/plugin/src/main/java/org/moddingx/packdev/platform/curse/CursePlatform.java#L27

![图片](https://github.com/ModdingX/PackDev/assets/19922286/d9a8e8a3-d2f6-4c18-95da-f526b4985632)
